### PR TITLE
Additional service properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,22 @@ internal domain of the service as visible to the Consul DNS.
 * `com.microkubes.service.port` - the port on which the service listens to.
 * `com.microkubes.service.paths` - routing paths (separated by comma) for the incoming requests to be proxied to this microservice.
 
+Additional service configuration options:
 
+* `com.microkubes.service.preserve_host` - Whether to pass the `Host` header to the upstream API service. Default `false`.
+* `com.microkubes.service.retries` - The number of retries to execute upon failure to proxy. Default `5`.
+* `com.microkubes.service.strip_uri` - When matching an API via one of the `uris` prefixes, strip that matching prefix 
+from the upstream URI to be requested.  Default `true`.
+* `com.microkubes.service.upstream_connect_timeout` - The timeout in milliseconds for establishing a connection between
+the API Gateway and the service. Default `60000`.
+* `com.microkubes.service.upstream_read_timeout` - he timeout in milliseconds between two successive read operations for
+transmitting a request to your the service. Default `60000`.
+* `com.microkubes.service.upstream_send_timeout` - The timeout in milliseconds between two successive write operations
+for transmitting a request to the service. Default `60000`.
+* `com.microkubes.service.https_only` - To be enabled if you wish to only serve your API through HTTPS, on the appropriate
+port (8443 by default). Default `false`.
+* `com.microkubes.service.http_if_terminated` - Tell the API Gateway to consider the `X-Forwarded-Proto` header when enforcing
+HTTPS only traffic. Default `false`.
 
 # Security Integration
 

--- a/src/main/java/com/microkubes/tools/gateway/KongServiceRegistry.java
+++ b/src/main/java/com/microkubes/tools/gateway/KongServiceRegistry.java
@@ -6,6 +6,8 @@ import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.json.JSONObject;
 
+import java.util.Map;
+
 /**
  * {@link ServiceRegistry} for Kong Gateway.
  * Registers microservices as APIs on the Kong API Gateway.
@@ -51,6 +53,10 @@ public class KongServiceRegistry implements ServiceRegistry {
         obj.put("name", service.getName());
         obj.put("upstream_url", getUpstreamUrl(service));
         obj.put("uris", String.join(",", service.getPaths()));
+
+        for (Map.Entry<String, Object> entry : service.getProperties().entrySet()) {
+            obj.put(entry.getKey(), entry.getValue());
+        }
 
         return obj;
     }

--- a/src/main/java/com/microkubes/tools/gateway/ServiceInfo.java
+++ b/src/main/java/com/microkubes/tools/gateway/ServiceInfo.java
@@ -1,7 +1,9 @@
 package com.microkubes.tools.gateway;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * ServiceInfo holds the registration data for a Microservice on the platform.
@@ -13,6 +15,8 @@ public class ServiceInfo {
     private int port;
     private String[] paths;
 
+    private Map<String, Object> properties = new HashMap<>();
+
     /**
      * Constructs new empty {@link ServiceInfo}.
      */
@@ -20,7 +24,7 @@ public class ServiceInfo {
     }
 
     /**
-     * Constructs {@link ServiceInfo} from the given serice registration data.
+     * Constructs {@link ServiceInfo} from the given service registration data.
      *
      * @param name  the microservice name. The service will be registered under this name on the API Gateway.
      * @param host  the service container host name. This is used in the name to IP resolution when routing messages to
@@ -29,11 +33,12 @@ public class ServiceInfo {
      *              can be accessed on.
      * @param paths list of URI paths used as patters for routing messages to the service.
      */
-    public ServiceInfo(String name, String host, int port, String[] paths) {
+    public ServiceInfo(String name, String host, int port, String[] paths, Map<String, Object> properties) {
         this.name = name;
         this.host = host;
         this.port = port;
         this.paths = paths;
+        this.properties = properties;
     }
 
     public String getName() {
@@ -68,6 +73,14 @@ public class ServiceInfo {
         this.paths = paths;
     }
 
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
     /**
      * Performs validation on the {@link ServiceInfo} data.
      *
@@ -96,6 +109,7 @@ public class ServiceInfo {
         private String host;
         private int port;
         private List<String> paths;
+        private Map<String, Object> properties = new HashMap<>();
 
         private ServiceInfoBuilder() {
         }
@@ -147,6 +161,11 @@ public class ServiceInfo {
             return this;
         }
 
+        public ServiceInfoBuilder setProperty(String name, Object value) {
+            this.properties.put(name, value);
+            return this;
+        }
+
         /**
          * Builds the {@link ServiceInfo} from the data collected by this builder object.
          *
@@ -154,7 +173,7 @@ public class ServiceInfo {
          * @throws ValidationException if the data provided is not valid.
          */
         public ServiceInfo getServiceInfo() throws ValidationException {
-            ServiceInfo service = new ServiceInfo(name, host, port, paths.toArray(new String[]{}));
+            ServiceInfo service = new ServiceInfo(name, host, port, paths.toArray(new String[]{}), properties);
             service.validate();
             return service;
         }

--- a/src/main/java/com/microkubes/tools/gateway/ServiceInfo.java
+++ b/src/main/java/com/microkubes/tools/gateway/ServiceInfo.java
@@ -26,12 +26,14 @@ public class ServiceInfo {
     /**
      * Constructs {@link ServiceInfo} from the given service registration data.
      *
-     * @param name  the microservice name. The service will be registered under this name on the API Gateway.
-     * @param host  the service container host name. This is used in the name to IP resolution when routing messages to
-     *              the microservice.
-     * @param port  the port on which the service listens to. This is the port on the container on which the service can
-     *              can be accessed on.
-     * @param paths list of URI paths used as patters for routing messages to the service.
+     * @param name       the microservice name. The service will be registered under this name on the API Gateway.
+     * @param host       the service container host name. This is used in the name to IP resolution when routing messages to
+     *                   the microservice.
+     * @param port       the port on which the service listens to. This is the port on the container on which the service can
+     *                   can be accessed on.
+     * @param paths      list of URI paths used as patters for routing messages to the service.
+     * @param properties {@link Map} containing additional service properties for finer control over the registered
+     *                   service.
      */
     public ServiceInfo(String name, String host, int port, String[] paths, Map<String, Object> properties) {
         this.name = name;

--- a/src/main/java/com/microkubes/tools/gateway/spring/ServiceRegistryConfig.java
+++ b/src/main/java/com/microkubes/tools/gateway/spring/ServiceRegistryConfig.java
@@ -28,6 +28,7 @@ public class ServiceRegistryConfig {
     @Value("${com.microkubes.service.paths}")
     private String[] servicePaths;
 
+    // Additional service API configuration properties
     @Value("${com.microkubes.service.preserve_host:false}")
     private Boolean preserveHost;
     @Value("${com.microkubes.service.retries:5}")

--- a/src/main/java/com/microkubes/tools/gateway/spring/ServiceRegistryConfig.java
+++ b/src/main/java/com/microkubes/tools/gateway/spring/ServiceRegistryConfig.java
@@ -1,13 +1,19 @@
 package com.microkubes.tools.gateway.spring;
 
-import com.microkubes.tools.gateway.*;
+import com.microkubes.tools.gateway.KongServiceRegistry;
+import com.microkubes.tools.gateway.ServiceInfo;
+import com.microkubes.tools.gateway.ServiceRegistry;
+import com.microkubes.tools.gateway.ValidationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Configuration
-@ConditionalOnProperty(prefix = "com.microkubes.gateway", name="gateway-url")
+@ConditionalOnProperty(prefix = "com.microkubes.gateway", name = "gateway-url")
 public class ServiceRegistryConfig {
 
     @Value("${com.microkubes.gateway.gateway-url}")
@@ -22,6 +28,20 @@ public class ServiceRegistryConfig {
     @Value("${com.microkubes.service.paths}")
     private String[] servicePaths;
 
+    @Value("${com.microkubes.service.preserve_host:false}")
+    private Boolean preserveHost;
+    @Value("${com.microkubes.service.retries:5}")
+    private Integer retries;
+    @Value("${com.microkubes.service.strip_uri:false}")
+    private Boolean stripUri;
+    @Value("${com.microkubes.service.upstream_connect_timeout:60000}")
+    private Integer upstreamConnectTimeout;
+    @Value("${com.microkubes.service.upstream_read_timeout:60000}")
+    private Integer upstreamReadTimeout;
+    @Value("${com.microkubes.service.upstream_send_timeout:60000}")
+    private Integer upstreamSendTimeout;
+
+
     @Bean
     public ServiceRegistry getServiceRegistry() {
         return new KongServiceRegistry(apiGatewayURL);
@@ -29,15 +49,29 @@ public class ServiceRegistryConfig {
 
     @Bean
     public ServiceInfo getServiceInfo() throws ValidationException {
-        ServiceInfo.ServiceInfoBuilder serviceInfo =  ServiceInfo
+        ServiceInfo.ServiceInfoBuilder serviceInfo = ServiceInfo
                 .NewService(serviceName)
                 .host(serviceHost)
                 .port(servicePort);
 
-        for( String path: servicePaths) {
+        for (String path : servicePaths) {
             serviceInfo.addPath(path);
         }
 
-        return  serviceInfo.getServiceInfo();
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("preserve_host", preserveHost);
+        properties.put("retries", retries);
+        properties.put("strip_uri", stripUri);
+        properties.put("upstream_connect_timeout", upstreamConnectTimeout);
+        properties.put("upstream_read_timeout", upstreamReadTimeout);
+        properties.put("upstream_send_timeout", upstreamSendTimeout);
+
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            if (entry.getValue() != null) {
+                serviceInfo.setProperty(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return serviceInfo.getServiceInfo();
     }
 }

--- a/src/main/java/com/microkubes/tools/gateway/spring/ServiceRegistryConfig.java
+++ b/src/main/java/com/microkubes/tools/gateway/spring/ServiceRegistryConfig.java
@@ -32,7 +32,7 @@ public class ServiceRegistryConfig {
     private Boolean preserveHost;
     @Value("${com.microkubes.service.retries:5}")
     private Integer retries;
-    @Value("${com.microkubes.service.strip_uri:false}")
+    @Value("${com.microkubes.service.strip_uri:true}")
     private Boolean stripUri;
     @Value("${com.microkubes.service.upstream_connect_timeout:60000}")
     private Integer upstreamConnectTimeout;
@@ -40,6 +40,10 @@ public class ServiceRegistryConfig {
     private Integer upstreamReadTimeout;
     @Value("${com.microkubes.service.upstream_send_timeout:60000}")
     private Integer upstreamSendTimeout;
+    @Value("${com.microkubes.service.https_only:false}")
+    private Integer httpsOnly;
+    @Value("${com.microkubes.service.http_if_terminated:false}")
+    private Integer httpIfTerminated;
 
 
     @Bean
@@ -65,6 +69,8 @@ public class ServiceRegistryConfig {
         properties.put("upstream_connect_timeout", upstreamConnectTimeout);
         properties.put("upstream_read_timeout", upstreamReadTimeout);
         properties.put("upstream_send_timeout", upstreamSendTimeout);
+        properties.put("https_only", httpsOnly);
+        properties.put("http_if_terminated", httpIfTerminated);
 
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
             if (entry.getValue() != null) {


### PR DESCRIPTION
Adds support for additional configuration options when registering a service with Kong API Gateway.

Supports finer grained control with the following properties:

* `com.microkubes.service.preserve_host` - Whether to pass the `Host` header to the upstream API service. Default `false`.
* `com.microkubes.service.retries` - The number of retries to execute upon failure to proxy. Default `5`.
* `com.microkubes.service.strip_uri` - When matching an API via one of the `uris` prefixes, strip that matching prefix 
from the upstream URI to be requested.  Default `true`.
* `com.microkubes.service.upstream_connect_timeout` - The timeout in milliseconds for establishing a connection between
the API Gateway and the service. Default `60000`.
* `com.microkubes.service.upstream_read_timeout` - he timeout in milliseconds between two successive read operations for
transmitting a request to your the service. Default `60000`.
* `com.microkubes.service.upstream_send_timeout` - The timeout in milliseconds between two successive write operations
for transmitting a request to the service. Default `60000`.
* `com.microkubes.service.https_only` - To be enabled if you wish to only serve your API through HTTPS, on the appropriate
port (8443 by default). Default `false`.
* `com.microkubes.service.http_if_terminated` - Tell the API Gateway to consider the `X-Forwarded-Proto` header when enforcing
HTTPS only traffic. Default `false`.
